### PR TITLE
check for correct terraform version

### DIFF
--- a/qhub_ops/template/{{ cookiecutter.repo_directory }}/README.md
+++ b/qhub_ops/template/{{ cookiecutter.repo_directory }}/README.md
@@ -21,7 +21,7 @@ In practice GitHub Actions controls everything.
  - [gcloud](https://cloud.google.com/sdk/install)
  - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
  - [helm](https://helm.sh/) version **3+**
- - [terraform](https://www.terraform.io/downloads.html)
+ - [terraform](https://www.terraform.io/downloads.html)  version **v0.12.24**
 
 ## Development
 

--- a/qhub_ops/template/{{ cookiecutter.repo_directory }}/scripts/00-guided-install.sh
+++ b/qhub_ops/template/{{ cookiecutter.repo_directory }}/scripts/00-guided-install.sh
@@ -13,6 +13,12 @@ if [ ! -f "$(command -v terraform)" ]; then
     exit 1
 fi
 
+# 02 Check version of Terraform
+if ! terraform --version | grep -q "v0.12.24"; then 
+	echo "Error: Please install Terraform v0.12.24"
+	exit 1
+fi
+
 # 03 Check Environment Variables
 {% if cookiecutter.provider == 'gcp' %}
 if [[ -v GOOGLE_CREDENTIALS ]] || [[ -v PROJECT_ID ]]; then


### PR DESCRIPTION
If the correct version of terraform is not installed and the user tries to update the terraform state with a newer version of terraform, the state gets corrupted. I faced this issue recently and had to teardown the cluster and recreate it with the correct version to ensure that automated deployment works.

Partially fixes : https://github.com/Quansight/quansight-internal-support/issues/31